### PR TITLE
Update tilt.rb

### DIFF
--- a/tilt.rb
+++ b/tilt.rb
@@ -6,7 +6,6 @@ class Tilt < Formula
   desc "Tilt powers multi-service developments for teams that deploy to Kubernetes."
   homepage "https://tilt.dev/"
   version "0.22.13"
-  bottle :unneeded
 
   if OS.mac? && Hardware::CPU.intel?
     url "https://github.com/tilt-dev/tilt/releases/download/v0.22.13/tilt.0.22.13.mac.x86_64.tar.gz"


### PR DESCRIPTION
apparently `bottle :unneeded` is deprecated:

```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the tilt-dev/tap tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/tilt-dev/homebrew-tap/tilt.rb:9
```